### PR TITLE
Cosmetics - correct documentation link

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "codeowners": ["@pepellee"],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/PePeLLee/home-assistant-pse-calendar",
+  "documentation": "https://github.com/PePeLLee/home-assistant-rce",
   "iot_class": "local_polling",
   "requirements": [],
   "issue_tracker": "https://github.com/PePeLLee/home-assistant-rce/issues",


### PR DESCRIPTION
Corrects link to documentation - pointing to the other repo (seemingly without the documentation)

Fixes https://github.com/PePeLLee/home-assistant-rce/issues/9